### PR TITLE
fix reported version and use normalized macro

### DIFF
--- a/memprof.c
+++ b/memprof.c
@@ -774,7 +774,7 @@ ZEND_EXTENSION();
 
 ZEND_DLEXPORT zend_extension zend_extension_entry = {
 	MEMPROF_NAME,
-	MEMPROF_VERSION,
+	PHP_MEMPROF_VERSION,
 	"Arnaud Le Blanc",
 	"https://github.com/arnaud-lb/php-memory-profiler",
 	"Copyright (c) 2013",
@@ -843,7 +843,7 @@ zend_module_entry memprof_module_entry = {
 	PHP_RSHUTDOWN(memprof),
 	PHP_MINFO(memprof),
 #if ZEND_MODULE_API_NO >= 20010901
-	MEMPROF_VERSION,
+	PHP_MEMPROF_VERSION,
 #endif
 	STANDARD_MODULE_PROPERTIES
 };

--- a/php_memprof.h
+++ b/php_memprof.h
@@ -18,7 +18,7 @@
 #define PHP_MEMPROF_H
 
 #define MEMPROF_NAME "memprof"
-#define MEMPROF_VERSION "1.0.0"
+#define PHP_MEMPROF_VERSION "2.0.0"
 
 extern zend_module_entry memprof_module_entry;
 #define phpext_memprof_ptr &memprof_module_entry


### PR DESCRIPTION
Using normalized macro will avoid such (so current) mistake, as this macro is checked during the upload on PECL forge