### PR TITLE
Replace obsolete AC_TRY_FOO with AC_FOO_IFELSE

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -52,22 +52,21 @@ if test "$PHP_MEMPROF" != "no"; then
   PHP_SUBST(MEMPROF_SHARED_LIBADD)
 
   AC_MSG_CHECKING(for malloc hooks)
-  AC_TRY_COMPILE([
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     #include <malloc.h>
     extern void * malloc_hook(size_t size, const void *caller);
     extern void * realloc_hook(void *ptr, size_t size, const void *caller);
     extern void free_hook(void *ptr, const void *caller);
     extern void * memalign_hook(size_t alignment, size_t size, const void *caller);
-  ],
-  [
+  ]], [[
     __malloc_hook = malloc_hook;
     __free_hook = free_hook;
     __realloc_hook = realloc_hook;
     __memalign_hook = memalign_hook;
-  ],[
+  ]])],[
     AC_DEFINE([HAVE_MALLOC_HOOKS], 1, [Define to 1 if libc supports malloc hooks])
     AC_MSG_RESULT(yes)
-  ], [
+  ],[
     AC_MSG_RESULT(no)
   ])
 


### PR DESCRIPTION
Hello,

Autoconf made several macros obsolete including the AC_TRY_COMPILE and AC_TRY_RUN in 2000 and since Autoconf 2.50: http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2

These macros should be replaced with the current AC_FOO_IFELSE instead.

It is fairly safe to upgrade and take the recommendation advice of autoconf upgrade manual since the upgrade should be compatible at least with PHP versions 5.4 and up, on some systems even with PHP 5.3. PHP versions from 5.4 to 7.1 require Autoconf 2.59+ and PHP 7.2+ require Autoconf 2.64+.

This patch was created with the help of autoupdate script.

Reference docs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.59/autoconf.pdf
