### PR TITLE
fix minimal version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ config.status
 config.sub
 configure
 configure.in
+configure.ac
 install-sh
 libtool
 ltmain.sh
@@ -26,3 +27,4 @@ missing
 mkinstalldirs
 modules
 run-tests.php
+memprof-*.tgz

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Example output:
 
 ## PHP versions
 
-The current branch supports PHP 7 and PHP 8.
+The current branch supports PHP 7.1 to PHP 8.
 
 The php5 branch supports PHP 5.
 

--- a/package.xml
+++ b/package.xml
@@ -34,6 +34,16 @@
    <file name="LICENSE" role="doc" />
    <file name="INTERNALS.md" role="doc" />
    <file name="README.md" role="doc" />
+   <dir name="tests">
+     <file name="001.phpt" role="test" />
+     <file name="002.phpt" role="test" />
+     <file name="003.phpt" role="test" />
+     <file name="004.phpt" role="test" />
+     <file name="005.phpt" role="test" />
+     <file name="006.phpt" role="test" />
+     <file name="common.php" role="test" />
+     <file name="zend_pass_function.phpt" role="test" />
+   </dir>
   </dir>
  </contents>
  <dependencies>

--- a/package.xml
+++ b/package.xml
@@ -39,10 +39,10 @@
  <dependencies>
   <required>
    <php>
-    <min>7.0.0</min>
+    <min>7.1.0</min>
    </php>
    <pearinstaller>
-    <min>1.4.8</min>
+    <min>1.10.0</min>
    </pearinstaller>
   </required>
  </dependencies>


### PR DESCRIPTION
According to https://github.com/arnaud-lb/php-memory-profiler/commit/4d8670ada0ce8d8ee943c3d55bfd224fde2c63b2#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5

Only 7.1+ is supported

And indeed, build fails with 7.0

```
/builddir/build/BUILD/php70-php-pecl-memprof-2.1.1/NTS/util.c: In function 'get_function_name':
/builddir/build/BUILD/php70-php-pecl-memprof-2.1.1/NTS/util.c:59:49: error: 'zend_pass_function' undeclared (first use in this function); did you mean 'zend_call_function'?
   59 |  if (&execute_data->func->internal_function == &zend_pass_function) {
      |                                                 ^~~~~~~~~~~~~~~~~~
      |                                                 zend_call_function
/builddir/build/BUILD/php70-php-pecl-memprof-2.1.1/NTS/util.c:59:49: note: each undeclared identifier is reported only once for each function it appears in

```