### PR TITLE
Auto dump profile on memory exhaustion

### DIFF
--- a/memprof.c
+++ b/memprof.c
@@ -34,6 +34,7 @@
 
 #define MEMPROF_ENV_PROFILE "MEMPROF_PROFILE"
 #define MEMPROF_FLAG_NATIVE "native"
+#define MEMPROF_FLAG_DUMP_ON_LIMIT "dump_on_limit"
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
@@ -132,6 +133,8 @@
 
 #endif /* HAVE_MALLOC_HOOKS */
 
+#define MEMORY_LIMIT_ERROR_PREFIX "Allowed memory size of"
+
 typedef LIST_HEAD(_alloc_list_head, _alloc) alloc_list_head;
 
 /* a call frame */
@@ -168,6 +171,11 @@ typedef struct _alloc_buckets {
 	alloc_bucket_item ** buckets;
 } alloc_buckets;
 
+static void dump_callgrind(php_stream * stream);
+static void dump_pprof(php_stream * stream);
+
+static ZEND_DECLARE_MODULE_GLOBALS(memprof)
+
 #if HAVE_MALLOC_HOOKS
 static void * malloc_hook(size_t size, const void *caller);
 static void * realloc_hook(void *ptr, size_t size, const void *caller);
@@ -188,12 +196,19 @@ static void (*old_zend_execute)(zend_execute_data *execute_data);
 static void (*old_zend_execute_internal)(zend_execute_data *execute_data_ptr, zval *return_value);
 #define zend_execute_fn zend_execute_ex
 
+#if ZEND_MODULE_API_NO < 20170718 /* PHP 7.1 - 7.2 */
+static void (*old_zend_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
+#define MEMPROF_ZEND_ERROR_CB_ARGS_PASSTHRU type, error_filename, error_lineno, format, args
+#elif ZEND_MODULE_API_NO < 20200930 /* PHP 7.3 - 7.4 */
+static void (*old_zend_error_cb)(int type, const char *error_filename, const uint32_t error_lineno, const char *format, va_list args);
+#define MEMPROF_ZEND_ERROR_CB_ARGS_PASSTHRU type, error_filename, error_lineno, format, args
+#else /* PHP 8 */
+static void (*old_zend_error_cb)(int type, const char *error_filename, const uint32_t error_lineno, zend_string *message);
+#define MEMPROF_ZEND_ERROR_CB_ARGS_PASSTHRU type, error_filename, error_lineno, message
+#endif
+
 static PHP_INI_MH((*origOnChangeMemoryLimit)) = NULL;
 
-#define MEMPROF_ENABLED			(1<<0)
-#define MEMPROF_ENABLED_NATIVE  (1<<1)
-
-static int memprof_enabled = 0;
 static int memprof_dumped = 0;
 static int track_mallocs = 0;
 
@@ -571,7 +586,7 @@ static void * zend_malloc_handler(size_t size)
 {
 	void *result;
 
-	assert(memprof_enabled);
+	assert(MEMPROF_G(profile_flags).enabled);
 
 	WITHOUT_MALLOC_HOOKS {
 
@@ -592,7 +607,7 @@ static void * zend_malloc_handler(size_t size)
 
 static void zend_free_handler(void * ptr)
 {
-	assert(memprof_enabled);
+	assert(MEMPROF_G(profile_flags).enabled);
 
 	WITHOUT_MALLOC_HOOKS {
 
@@ -617,7 +632,7 @@ static void * zend_realloc_handler(void * ptr, size_t size)
 	void *result;
 	alloc *a;
 
-	assert(memprof_enabled);
+	assert(MEMPROF_G(profile_flags).enabled);
 
 	WITHOUT_MALLOC_HOOKS {
 
@@ -667,7 +682,7 @@ static void memprof_zend_execute(zend_execute_data *execute_data)
 
 	old_zend_execute(execute_data);
 
-	if (memprof_enabled) {
+	if (MEMPROF_G(profile_flags).enabled) {
 		current_frame = current_frame->prev;
 		current_alloc_list = &current_frame->allocs;
 	}
@@ -708,10 +723,102 @@ static void memprof_zend_execute_internal(zend_execute_data *execute_data_ptr, z
 		old_zend_execute_internal(execute_data_ptr, return_value);
 	}
 
-	if (!ignore && memprof_enabled) {
+	if (!ignore && MEMPROF_G(profile_flags).enabled) {
 		current_frame = current_frame->prev;
 		current_alloc_list = &current_frame->allocs;
 	}
+}
+
+static zend_bool should_autodump(int error_type, const char *message) {
+	if (EXPECTED(error_type != E_ERROR)) {
+		return 0;
+	}
+
+	if (EXPECTED(!MEMPROF_G(profile_flags).dump_on_limit)) {
+		return 0;
+	}
+
+	if (EXPECTED(strncmp(MEMORY_LIMIT_ERROR_PREFIX, message, strlen(MEMORY_LIMIT_ERROR_PREFIX)) != 0)) {
+		return 0;
+	}
+
+	return 1;
+}
+
+static char * generate_filename(const char * format) {
+	char * filename;
+	struct timeval tv;
+	int64_t ts;
+	const char * output_dir = MEMPROF_G(output_dir);
+	char slash[] = "\0";
+
+	gettimeofday(&tv, NULL);
+	ts = ((uint64_t) tv.tv_sec) * 0x100000 + (((uint64_t) tv.tv_usec) % 0x100000);
+
+	if (!IS_SLASH(output_dir[strlen(output_dir)-1])) {
+		slash[0] = DEFAULT_SLASH;
+	}
+
+	spprintf(&filename, 0, "%s%smemprof.%s.%ld", output_dir, slash, format, ts);
+
+	return filename;
+}
+
+#if ZEND_MODULE_API_NO < 20170718 /* PHP 7.1 - 7.2 */
+static void memprof_zend_error_cb(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args)
+#elif ZEND_MODULE_API_NO < 20200930 /* PHP 7.3 - 7.4 */
+static void memprof_zend_error_cb(int type, const char *error_filename, const uint32_t error_lineno, const char *format, va_list args)
+#else /* PHP 8 */
+static void memprof_zend_error_cb(int type, const char *error_filename, const uint32_t error_lineno, zend_string *message)
+#endif
+{
+	char * filename;
+	php_stream * stream;
+#if ZEND_MODULE_API_NO < 20200930
+	const char * msg = format;
+#else
+	const char * msg = ZSTR_VAL(message);
+#endif
+
+	if (EXPECTED(!MEMPROF_G(profile_flags).enabled)) {
+		old_zend_error_cb(MEMPROF_ZEND_ERROR_CB_ARGS_PASSTHRU);
+		return;
+	}
+
+	if (EXPECTED(!should_autodump(type, msg))) {
+		old_zend_error_cb(MEMPROF_ZEND_ERROR_CB_ARGS_PASSTHRU);
+		return;
+	}
+
+	zend_mm_set_heap(orig_zheap);
+	zend_set_memory_limit((size_t)Z_L(-1) >> (size_t)Z_L(1));
+	zend_mm_set_heap(zheap);
+
+	WITHOUT_MALLOC_TRACKING {
+		if (MEMPROF_G(output_format) == FORMAT_CALLGRIND) {
+			filename = generate_filename("callgrind");
+			stream = php_stream_open_wrapper_ex(filename, "w", 0, NULL, NULL);
+			if (stream != NULL) {
+				dump_callgrind(stream);
+			}
+			php_stream_free(stream, PHP_STREAM_FREE_CLOSE);
+			efree(filename);
+		} else if (MEMPROF_G(output_format) == FORMAT_PPROF) {
+			filename = generate_filename("callgrind");
+			stream = php_stream_open_wrapper_ex(filename, "w", 0, NULL, NULL);
+			if (stream != NULL) {
+				dump_pprof(stream);
+			}
+			php_stream_free(stream, PHP_STREAM_FREE_CLOSE);
+			efree(filename);
+		}
+	} END_WITHOUT_MALLOC_TRACKING;
+
+	zend_mm_set_heap(orig_zheap);
+	zend_set_memory_limit(PG(memory_limit));
+	zend_mm_set_heap(zheap);
+
+	old_zend_error_cb(MEMPROF_ZEND_ERROR_CB_ARGS_PASSTHRU);
 }
 
 static PHP_INI_MH(OnChangeMemoryLimit)
@@ -728,7 +835,7 @@ static PHP_INI_MH(OnChangeMemoryLimit)
 		return ret;
 	}
 
-	if (memprof_enabled && orig_zheap) {
+	if (MEMPROF_G(profile_flags).enabled && orig_zheap) {
 		zend_mm_set_heap(orig_zheap);
 		zend_set_memory_limit(PG(memory_limit));
 		zend_mm_set_heap(zheap);
@@ -737,9 +844,9 @@ static PHP_INI_MH(OnChangeMemoryLimit)
 	return SUCCESS;
 }
 
-static void memprof_enable(int flags)
+static void memprof_enable(memprof_profile_flags * pf)
 {
-	assert(flags & MEMPROF_ENABLED);
+	assert(pf->enabled);
 
 	alloc_buckets_init(&current_alloc_buckets);
 
@@ -749,12 +856,11 @@ static void memprof_enable(int flags)
 	current_frame = &root_frame;
 	current_alloc_list = &root_frame.allocs;
 
-	if (flags & MEMPROF_ENABLED_NATIVE) {
+	if (pf->native) {
 		MALLOC_HOOK_SAVE_OLD();
 		MALLOC_HOOK_SET_OWN();
 	}
 
-	memprof_enabled = flags;
 	memprof_dumped = 0;
 
 	if (is_zend_mm()) {
@@ -790,11 +896,11 @@ static void memprof_disable()
 		free(zheap);
 	}
 
-	if (memprof_enabled & MEMPROF_ENABLED_NATIVE) {
+	if (MEMPROF_G(profile_flags).native) {
 		MALLOC_HOOK_RESTORE_OLD();
 	}
 
-	memprof_enabled = 0;
+	MEMPROF_G(profile_flags).enabled = 0;
 
 	destroy_frame(&root_frame);
 
@@ -861,7 +967,7 @@ static zend_string* read_env_get_post(char *name, size_t len)
 	return NULL;
 }
 
-static int should_autostart()
+static void parse_trigger(memprof_profile_flags * pf)
 {
 	char *saveptr;
 	const char *delim = ",";
@@ -869,20 +975,21 @@ static int should_autostart()
 
 	zend_string *value = read_env_get_post(MEMPROF_ENV_PROFILE, strlen(MEMPROF_ENV_PROFILE));
 	if (value == NULL) {
-		return 0;
+		return;
 	}
 
-	int autostart = ZSTR_LEN(value) > 0 ? MEMPROF_ENABLED : 0;
+	pf->enabled = ZSTR_LEN(value) > 0;
 
 	for (flag = strtok_r(ZSTR_VAL(value), delim, &saveptr); flag != NULL; flag = strtok_r(NULL, delim, &saveptr)) {
 		if (HAVE_MALLOC_HOOKS && strcmp(MEMPROF_FLAG_NATIVE, flag) == 0) {
-			autostart |= MEMPROF_ENABLED_NATIVE;
+			pf->native = 1;
+		}
+		if (strcmp(MEMPROF_FLAG_DUMP_ON_LIMIT, flag) == 0) {
+			pf->dump_on_limit = 1;
 		}
 	}
 
 	zend_string_release(value);
-
-	return autostart;
 }
 
 ZEND_DLEXPORT int memprof_zend_startup(zend_extension *extension)
@@ -956,9 +1063,7 @@ const zend_function_entry memprof_function_overrides[] = {
 /* {{{ memprof_module_entry
  */
 zend_module_entry memprof_module_entry = {
-#if ZEND_MODULE_API_NO >= 20010901
 	STANDARD_MODULE_HEADER,
-#endif
 	MEMPROF_NAME,
 	memprof_functions,
 	PHP_MINIT(memprof),
@@ -966,16 +1071,38 @@ zend_module_entry memprof_module_entry = {
 	PHP_RINIT(memprof),
 	PHP_RSHUTDOWN(memprof),
 	PHP_MINFO(memprof),
-#if ZEND_MODULE_API_NO >= 20010901
 	PHP_MEMPROF_VERSION,
-#endif
-	STANDARD_MODULE_PROPERTIES
+	PHP_MODULE_GLOBALS(memprof),
+	PHP_GINIT(memprof),
+	NULL,
+	NULL,
+	STANDARD_MODULE_PROPERTIES_EX
 };
 /* }}} */
 
 #ifdef COMPILE_DL_MEMPROF
+#	ifdef ZTS
+ZEND_TSRMLS_CACHE_DEFINE()
+#	endif
 ZEND_GET_MODULE(memprof)
 #endif
+
+#ifdef P_tmpdir
+#	define MEMPROF_TEMP_DIR P_tmpdir
+#else
+#	ifdef PHP_WIN32
+#		define MEMPROF_TEMP_DIR "C:\\Windows\\Temp"
+#	else
+#		define MEMPROF_TEMP_DIR "/tmp"
+#	endif
+#endif
+
+/* {{{ PHP_INI_BEGIN
+ */
+PHP_INI_BEGIN()
+	STD_PHP_INI_ENTRY("memprof.output_dir", MEMPROF_TEMP_DIR, PHP_INI_ALL, OnUpdateStringUnempty, output_dir, zend_memprof_globals, memprof_globals)
+PHP_INI_END()
+/* }}} */
 
 /* {{{ PHP_MINIT_FUNCTION
  */
@@ -983,6 +1110,8 @@ PHP_MINIT_FUNCTION(memprof)
 {
 	zend_ini_entry * entry;
 	const zend_function_entry * fentry;
+
+	REGISTER_INI_ENTRIES();
 
 	entry = zend_hash_str_find_ptr(EG(ini_directives), "memory_limit", sizeof("memory_limit")-1);
 
@@ -1003,6 +1132,9 @@ PHP_MINIT_FUNCTION(memprof)
 			zend_error(E_WARNING, "memprof: Could not override %s(), return value from this function may be be accurate.", fentry->fname);
 		}
 	}
+
+	old_zend_error_cb = zend_error_cb;
+	zend_error_cb = memprof_zend_error_cb;
 
 	return SUCCESS;
 }
@@ -1030,11 +1162,15 @@ PHP_MSHUTDOWN_FUNCTION(memprof)
  */
 PHP_RINIT_FUNCTION(memprof)
 {
-	int flags = should_autostart();
+#if defined(ZTS) && defined(COMPILE_DL_FOO)
+	ZEND_TSRMLS_CACHE_UPDATE();
+#endif
 
-	if (flags) {
+	parse_trigger(&MEMPROF_G(profile_flags));
+
+	if (MEMPROF_G(profile_flags).enabled) {
 		disable_opcache();
-		memprof_enable(flags);
+		memprof_enable(&MEMPROF_G(profile_flags));
 	}
 
 	return SUCCESS;
@@ -1045,7 +1181,7 @@ PHP_RINIT_FUNCTION(memprof)
  */
 PHP_RSHUTDOWN_FUNCTION(memprof)
 {
-	if (memprof_enabled) {
+	if (MEMPROF_G(profile_flags).enabled) {
 		memprof_disable();
 	}
 
@@ -1060,11 +1196,22 @@ PHP_MINFO_FUNCTION(memprof)
 	php_info_print_table_start();
 	php_info_print_table_header(2, "memprof support", "enabled");
 	php_info_print_table_header(2, "memprof version", PHP_MEMPROF_VERSION);
-	php_info_print_table_header(2, "memprof native malloc support", HAVE_MALLOC_HOOKS ? "yes" : "no");
+	php_info_print_table_header(2, "memprof native malloc support", HAVE_MALLOC_HOOKS ? "Yes" : "No");
 #if MEMPROF_DEBUG
 	php_info_print_table_header(2, "debug build", "Yes");
 #endif
 	php_info_print_table_end();
+
+	DISPLAY_INI_ENTRIES();
+}
+/* }}} */
+
+/* {{{ PHP_GINIT_FUNCTION
+ */
+PHP_GINIT_FUNCTION(memprof)
+{
+	memprof_globals->output_dir = NULL;
+	memprof_globals->output_format = FORMAT_CALLGRIND;
 }
 /* }}} */
 
@@ -1230,6 +1377,21 @@ static void dump_frame_callgrind(php_stream * stream, frame * f, char * fname, s
 	}
 }
 
+static void dump_callgrind(php_stream * stream) {
+	size_t total_size;
+	size_t total_count;
+
+	stream_printf(stream, "version: 1\n");
+	stream_printf(stream, "cmd: unknown\n");
+	stream_printf(stream, "positions: line\n");
+	stream_printf(stream, "events: MemorySize BlocksCount\n");
+	stream_printf(stream, "\n");
+
+	dump_frame_callgrind(stream, &root_frame, "root", &total_size, &total_count);
+
+	stream_printf(stream, "total: %zu %zu\n", total_size, total_count);
+}
+
 static void dump_frames_pprof(php_stream * stream, HashTable * symbols, frame * f)
 {
 	HashPosition pos;
@@ -1299,6 +1461,37 @@ static void dump_frames_pprof_symbols(php_stream * stream, HashTable * symbols, 
 	}
 }
 
+static void dump_pprof(php_stream * stream) {
+	HashTable symbols;
+
+	zend_hash_init(&symbols, 8, NULL, NULL, 0);
+
+	/* symbols */
+
+	stream_printf(stream, "--- symbol\n");
+	stream_printf(stream, "binary=todo.php\n");
+	dump_frames_pprof_symbols(stream, &symbols, &root_frame);
+	stream_printf(stream, "---\n");
+	stream_printf(stream, "--- profile\n");
+
+	/* profile header */
+
+	/* header count */
+	stream_write_word(stream, 0);
+	/* header words after this one */
+	stream_write_word(stream, 3);
+	/* format version */
+	stream_write_word(stream, 0);
+	/* sampling period */
+	stream_write_word(stream, 0);
+	/* unused padding */
+	stream_write_word(stream, 0);
+
+	dump_frames_pprof(stream, &symbols, &root_frame);
+
+	zend_hash_destroy(&symbols);
+}
+
 /* {{{ proto void memprof_dump_array(void)
    Returns current memory usage as an array */
 PHP_FUNCTION(memprof_dump_array)
@@ -1307,7 +1500,7 @@ PHP_FUNCTION(memprof_dump_array)
 		return;
 	}
 
-	if (!memprof_enabled) {
+	if (!MEMPROF_G(profile_flags).enabled) {
 		zend_throw_exception(EG(exception_class), "memprof_dump_array(): memprof is not enabled", 0);
 		return;
 	}
@@ -1328,14 +1521,12 @@ PHP_FUNCTION(memprof_dump_callgrind)
 {
 	zval *arg1;
 	php_stream *stream;
-	size_t total_size;
-	size_t total_count;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &arg1) == FAILURE) {
 		return;
 	}
 
-	if (!memprof_enabled) {
+	if (!MEMPROF_G(profile_flags).enabled) {
 		zend_throw_exception(EG(exception_class), "memprof_dump_callgrind(): memprof is not enabled", 0);
 		return;
 	}
@@ -1343,17 +1534,7 @@ PHP_FUNCTION(memprof_dump_callgrind)
 	php_stream_from_zval(stream, arg1);
 
 	WITHOUT_MALLOC_TRACKING {
-
-		stream_printf(stream, "version: 1\n");
-		stream_printf(stream, "cmd: unknown\n");
-		stream_printf(stream, "positions: line\n");
-		stream_printf(stream, "events: MemorySize BlocksCount\n");
-		stream_printf(stream, "\n");
-
-		dump_frame_callgrind(stream, &root_frame, "root", &total_size, &total_count);
-
-		stream_printf(stream, "total: %zu %zu\n", total_size, total_count);
-
+		dump_callgrind(stream);
 	} END_WITHOUT_MALLOC_TRACKING;
 
 	memprof_dumped = 1;
@@ -1366,13 +1547,12 @@ PHP_FUNCTION(memprof_dump_pprof)
 {
 	zval *arg1;
 	php_stream *stream;
-	HashTable symbols;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &arg1) == FAILURE) {
 		return;
 	}
 
-	if (!memprof_enabled) {
+	if (!MEMPROF_G(profile_flags).enabled) {
 		zend_throw_exception(EG(exception_class), "memprof_dump_pprof(): memprof is not enabled", 0);
 		return;
 	}
@@ -1380,34 +1560,7 @@ PHP_FUNCTION(memprof_dump_pprof)
 	php_stream_from_zval(stream, arg1);
 
 	WITHOUT_MALLOC_TRACKING {
-
-		zend_hash_init(&symbols, 8, NULL, NULL, 0);
-
-		/* symbols */
-
-		stream_printf(stream, "--- symbol\n");
-		stream_printf(stream, "binary=todo.php\n");
-		dump_frames_pprof_symbols(stream, &symbols, &root_frame);
-		stream_printf(stream, "---\n");
-		stream_printf(stream, "--- profile\n");
-
-		/* profile header */
-
-		/* header count */
-		stream_write_word(stream, 0);
-		/* header words after this one */
-		stream_write_word(stream, 3);
-		/* format version */
-		stream_write_word(stream, 0);
-		/* sampling period */
-		stream_write_word(stream, 0);
-		/* unused padding */
-		stream_write_word(stream, 0);
-
-		dump_frames_pprof(stream, &symbols, &root_frame);
-
-		zend_hash_destroy(&symbols);
-
+		dump_pprof(stream);
 	} END_WITHOUT_MALLOC_TRACKING;
 
 	memprof_dumped = 1;
@@ -1424,7 +1577,7 @@ PHP_FUNCTION(memprof_memory_get_usage)
 		return;
 	}
 
-	if (memprof_enabled && orig_zheap) {
+	if (MEMPROF_G(profile_flags).enabled && orig_zheap) {
 		zend_mm_set_heap(orig_zheap);
 		RETVAL_LONG(zend_memory_usage(real));
 		zend_mm_set_heap(zheap);
@@ -1444,7 +1597,7 @@ PHP_FUNCTION(memprof_memory_get_peak_usage)
 		return;
 	}
 
-	if (memprof_enabled && orig_zheap) {
+	if (MEMPROF_G(profile_flags).enabled && orig_zheap) {
 		zend_mm_set_heap(orig_zheap);
 		RETVAL_LONG(zend_memory_peak_usage(real));
 		zend_mm_set_heap(zheap);
@@ -1462,14 +1615,15 @@ PHP_FUNCTION(memprof_enable)
 		return;
 	}
 
-	if (memprof_enabled) {
+	if (MEMPROF_G(profile_flags).enabled) {
 		zend_throw_exception(EG(exception_class), "memprof_enable(): memprof is already enabled", 0);
 		return;
 	}
 
 	zend_error(E_WARNING, "Calling memprof_enable() manually may not work as expected because of PHP optimizations. Prefer using MEMPROF_PROFILE=1 as environment variable, GET, or POST");
 
-	memprof_enable(MEMPROF_ENABLED);
+	MEMPROF_G(profile_flags).enabled = 1;
+	memprof_enable(&MEMPROF_G(profile_flags));
 
 	RETURN_TRUE;
 }
@@ -1483,7 +1637,7 @@ PHP_FUNCTION(memprof_disable)
 		return;
 	}
 
-	if (!memprof_enabled) {
+	if (!MEMPROF_G(profile_flags).enabled) {
 		zend_throw_exception(EG(exception_class), "memprof_disable(): memprof is not enabled", 0);
 		return;
 	}
@@ -1502,7 +1656,7 @@ PHP_FUNCTION(memprof_enabled)
 		return;
 	}
 
-	RETURN_BOOL(memprof_enabled & MEMPROF_ENABLED);
+	RETURN_BOOL(MEMPROF_G(profile_flags).enabled);
 }
 /* }}} */
 
@@ -1515,7 +1669,8 @@ PHP_FUNCTION(memprof_enabled_flags)
 	}
 
 	array_init(return_value);
-	add_assoc_bool(return_value, "enabled", (memprof_enabled & MEMPROF_ENABLED) != 0);
-	add_assoc_bool(return_value, "native", (memprof_enabled & MEMPROF_ENABLED_NATIVE) != 0);
+	add_assoc_bool(return_value, "enabled", MEMPROF_G(profile_flags).enabled);
+	add_assoc_bool(return_value, "native", MEMPROF_G(profile_flags).native);
+	add_assoc_bool(return_value, "dump_on_limit", MEMPROF_G(profile_flags).dump_on_limit);
 }
 /* }}} */

--- a/php_memprof.h
+++ b/php_memprof.h
@@ -51,5 +51,6 @@ PHP_FUNCTION(memprof_memory_get_peak_usage);
 PHP_FUNCTION(memprof_enable);
 PHP_FUNCTION(memprof_disable);
 PHP_FUNCTION(memprof_enabled);
+PHP_FUNCTION(memprof_enabled_flags);
 
 #endif	/* PHP_MEMPROF_H */

--- a/php_memprof.h
+++ b/php_memprof.h
@@ -37,11 +37,31 @@ extern zend_module_entry memprof_module_entry;
 #   define PHP_FE_END { NULL, NULL, NULL, 0, 0 }
 #endif
 
+typedef enum {
+	FORMAT_CALLGRIND = 0,
+	FORMAT_PPROF = 1,
+} memprof_output_format;
+
+typedef struct _memprof_profile_flags {
+	zend_bool enabled;
+	zend_bool native;
+	zend_bool dump_on_limit;
+} memprof_profile_flags;
+
+ZEND_BEGIN_MODULE_GLOBALS(memprof)
+	const char * output_dir;
+	memprof_output_format output_format;
+	memprof_profile_flags profile_flags;
+ZEND_END_MODULE_GLOBALS(memprof)
+
+#define MEMPROF_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(memprof, v)
+
 PHP_MINIT_FUNCTION(memprof);
 PHP_MSHUTDOWN_FUNCTION(memprof);
 PHP_RINIT_FUNCTION(memprof);
 PHP_RSHUTDOWN_FUNCTION(memprof);
 PHP_MINFO_FUNCTION(memprof);
+PHP_GINIT_FUNCTION(memprof);
 
 PHP_FUNCTION(memprof_dump_callgrind);
 PHP_FUNCTION(memprof_dump_pprof);

--- a/tests/004.phpt
+++ b/tests/004.phpt
@@ -9,9 +9,11 @@ var_dump(memprof_enabled_flags());
 memprof_dump_array();
 --EXPECT--
 bool(true)
-array(2) {
+array(3) {
   ["enabled"]=>
   bool(true)
   ["native"]=>
+  bool(false)
+  ["dump_on_limit"]=>
   bool(false)
 }

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -1,17 +1,16 @@
 --TEST--
-Enable with environment variable
+Enable native profiling
 --ENV--
-MEMPROF_PROFILE=1
+MEMPROF_PROFILE=native
 --FILE--
 <?php
 var_dump(memprof_enabled());
 var_dump(memprof_enabled_flags());
-memprof_dump_array();
 --EXPECT--
 bool(true)
 array(2) {
   ["enabled"]=>
   bool(true)
   ["native"]=>
-  bool(false)
+  bool(true)
 }

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -8,9 +8,11 @@ var_dump(memprof_enabled());
 var_dump(memprof_enabled_flags());
 --EXPECT--
 bool(true)
-array(2) {
+array(3) {
   ["enabled"]=>
   bool(true)
   ["native"]=>
   bool(true)
+  ["dump_on_limit"]=>
+  bool(false)
 }

--- a/tests/autodump-disabled.phpt
+++ b/tests/autodump-disabled.phpt
@@ -1,0 +1,49 @@
+--TEST--
+autodump disabled
+--ENV--
+MEMPROF_PROFILE=1
+--FILE--
+<?php
+
+$dir = sys_get_temp_dir() . '/' . microtime(true);
+var_dump($dir);
+var_dump(mkdir($dir));
+var_dump(memprof_enabled_flags());
+
+$buf = str_repeat("a", 5<<20);
+
+register_shutdown_function(function () use (&$buf, $dir) {
+    $buf = "";
+    var_dump(scandir($dir));
+});
+
+ini_set("memprof.output_dir", $dir);
+ini_set("memory_limit", 15<<20);
+
+function f() {
+    $a = [];
+    for (;;) {
+        $a[] = str_repeat("a", 1<<20);
+    }
+}
+
+f();
+--EXPECTF--
+string(%d) "/tmp/%s"
+bool(true)
+array(3) {
+  ["enabled"]=>
+  bool(true)
+  ["native"]=>
+  bool(false)
+  ["dump_on_limit"]=>
+  bool(false)
+}
+
+Fatal error: Allowed memory size of 15728640 bytes exhausted%S (tried to allocate %d bytes) in %s on line%a
+array(2) {
+  [0]=>
+  string(1) "."
+  [1]=>
+  string(2) ".."
+}

--- a/tests/autodump.phpt
+++ b/tests/autodump.phpt
@@ -1,0 +1,51 @@
+--TEST--
+autodump
+--ENV--
+MEMPROF_PROFILE=dump_on_limit
+--FILE--
+<?php
+
+$dir = sys_get_temp_dir() . '/' . microtime(true);
+var_dump($dir);
+var_dump(mkdir($dir));
+var_dump(memprof_enabled_flags());
+
+$buf = str_repeat("a", 5<<20);
+
+register_shutdown_function(function () use (&$buf, $dir) {
+    $buf = "";
+    var_dump(scandir($dir));
+});
+
+ini_set("memprof.output_dir", $dir);
+ini_set("memory_limit", 15<<20);
+
+function f() {
+    $a = [];
+    for (;;) {
+        $a[] = str_repeat("a", 1<<20);
+    }
+}
+
+f();
+--EXPECTF--
+string(%d) "/tmp/%s"
+bool(true)
+array(3) {
+  ["enabled"]=>
+  bool(true)
+  ["native"]=>
+  bool(false)
+  ["dump_on_limit"]=>
+  bool(true)
+}
+
+Fatal error: Allowed memory size of 15728640 bytes exhausted%S (tried to allocate %d bytes) in %s on line%a
+array(3) {
+  [0]=>
+  string(1) "."
+  [1]=>
+  string(2) ".."
+  [2]=>
+  string(%d) "memprof.callgrind.%s"
+}


### PR DESCRIPTION
Support for automatically dumping the profile when the memory limit is exceeded.

This can be enabled by passing `dump_on_limit` to `MEMPROF_PROFILE`, like this:

```
export MEMPROF_PROFILE=dump_on_limit
php test.php
```

When the memory limit is exceeded, the profile is dumped in callgrind format in `/tmp` or `C:\Windows\Temp`.