### PR TITLE
add stub and auto-generated arginfo

### DIFF
--- a/memprof.c
+++ b/memprof.c
@@ -32,6 +32,12 @@
 #endif
 #include <assert.h>
 
+#if PHP_VERSION_ID < 80000
+#include "memprof_legacy_arginfo.h"
+#else
+#include "memprof_arginfo.h"
+#endif
+
 #define MEMPROF_ENV_PROFILE "MEMPROF_PROFILE"
 #define MEMPROF_FLAG_NATIVE "native"
 #define MEMPROF_FLAG_DUMP_ON_LIMIT "dump_on_limit"
@@ -1027,34 +1033,9 @@ ZEND_DLEXPORT zend_extension zend_extension_entry = {
 	STANDARD_ZEND_EXTENSION_PROPERTIES
 };
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_memprof_dump_callgrind, 0, 0, 1)
-	ZEND_ARG_INFO(0, handle)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_memprof_dump_pprof, 0, 0, 1)
-	ZEND_ARG_INFO(0, handle)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_INFO_EX(arginfo_memprof_memory_get_usage, 0, 0, 0)
 	ZEND_ARG_INFO(0, real)
 ZEND_END_ARG_INFO()
-
-/* {{{ memprof_functions[]
- */
-const zend_function_entry memprof_functions[] = {
-	PHP_FE(memprof_enabled, arginfo_void)
-	PHP_FE(memprof_enabled_flags, arginfo_void)
-	PHP_FE(memprof_enable, arginfo_void)
-	PHP_FE(memprof_disable, arginfo_void)
-	PHP_FE(memprof_dump_array, arginfo_void)
-	PHP_FE(memprof_dump_callgrind, arginfo_memprof_dump_callgrind)
-	PHP_FE(memprof_dump_pprof, arginfo_memprof_dump_pprof)
-	PHP_FE_END    /* Must be the last line in memprof_functions[] */
-};
-/* }}} */
 
 /* {{{ memprof_functions_overrides[]
  */
@@ -1070,7 +1051,7 @@ const zend_function_entry memprof_function_overrides[] = {
 zend_module_entry memprof_module_entry = {
 	STANDARD_MODULE_HEADER,
 	MEMPROF_NAME,
-	memprof_functions,
+	ext_functions,
 	PHP_MINIT(memprof),
 	PHP_MSHUTDOWN(memprof),
 	PHP_RINIT(memprof),

--- a/memprof.stub.php
+++ b/memprof.stub.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ */
+
+function memprof_enabled(): bool {}
+
+function memprof_enabled_flags(): array {}
+
+function memprof_enable(): bool {}
+
+function memprof_disable(): bool {}
+
+function memprof_dump_array(): void {}
+
+/**
+ * @param resource $handle
+ */
+function memprof_dump_callgrind($handle): void {}
+
+/**
+ * @param resource $handle
+ */
+function memprof_dump_pprof($handle): void {}
+
+

--- a/memprof_arginfo.h
+++ b/memprof_arginfo.h
@@ -1,0 +1,42 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: ce1c6e7b3be72716852657a9976e6c38c2af6722 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_memprof_enabled, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_memprof_enabled_flags, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_memprof_enable arginfo_memprof_enabled
+
+#define arginfo_memprof_disable arginfo_memprof_enabled
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_memprof_dump_array, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_memprof_dump_callgrind, 0, 1, IS_VOID, 0)
+	ZEND_ARG_INFO(0, handle)
+ZEND_END_ARG_INFO()
+
+#define arginfo_memprof_dump_pprof arginfo_memprof_dump_callgrind
+
+
+ZEND_FUNCTION(memprof_enabled);
+ZEND_FUNCTION(memprof_enabled_flags);
+ZEND_FUNCTION(memprof_enable);
+ZEND_FUNCTION(memprof_disable);
+ZEND_FUNCTION(memprof_dump_array);
+ZEND_FUNCTION(memprof_dump_callgrind);
+ZEND_FUNCTION(memprof_dump_pprof);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(memprof_enabled, arginfo_memprof_enabled)
+	ZEND_FE(memprof_enabled_flags, arginfo_memprof_enabled_flags)
+	ZEND_FE(memprof_enable, arginfo_memprof_enable)
+	ZEND_FE(memprof_disable, arginfo_memprof_disable)
+	ZEND_FE(memprof_dump_array, arginfo_memprof_dump_array)
+	ZEND_FE(memprof_dump_callgrind, arginfo_memprof_dump_callgrind)
+	ZEND_FE(memprof_dump_pprof, arginfo_memprof_dump_pprof)
+	ZEND_FE_END
+};

--- a/memprof_legacy_arginfo.h
+++ b/memprof_legacy_arginfo.h
@@ -1,0 +1,40 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: ce1c6e7b3be72716852657a9976e6c38c2af6722 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_memprof_enabled, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_memprof_enabled_flags arginfo_memprof_enabled
+
+#define arginfo_memprof_enable arginfo_memprof_enabled
+
+#define arginfo_memprof_disable arginfo_memprof_enabled
+
+#define arginfo_memprof_dump_array arginfo_memprof_enabled
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_memprof_dump_callgrind, 0, 0, 1)
+	ZEND_ARG_INFO(0, handle)
+ZEND_END_ARG_INFO()
+
+#define arginfo_memprof_dump_pprof arginfo_memprof_dump_callgrind
+
+
+ZEND_FUNCTION(memprof_enabled);
+ZEND_FUNCTION(memprof_enabled_flags);
+ZEND_FUNCTION(memprof_enable);
+ZEND_FUNCTION(memprof_disable);
+ZEND_FUNCTION(memprof_dump_array);
+ZEND_FUNCTION(memprof_dump_callgrind);
+ZEND_FUNCTION(memprof_dump_pprof);
+
+
+static const zend_function_entry ext_functions[] = {
+	ZEND_FE(memprof_enabled, arginfo_memprof_enabled)
+	ZEND_FE(memprof_enabled_flags, arginfo_memprof_enabled_flags)
+	ZEND_FE(memprof_enable, arginfo_memprof_enable)
+	ZEND_FE(memprof_disable, arginfo_memprof_disable)
+	ZEND_FE(memprof_dump_array, arginfo_memprof_dump_array)
+	ZEND_FE(memprof_dump_callgrind, arginfo_memprof_dump_callgrind)
+	ZEND_FE(memprof_dump_pprof, arginfo_memprof_dump_pprof)
+	ZEND_FE_END
+};

--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,9 @@
   <dir name="/">
    <file name="config.m4" role="src" />
    <file name="memprof.c" role="src" />
+   <file name="memprof.stub.php" role="src" />
+   <file name="memprof_arginfo.h" role="src" />
+   <file name="memprof_legacy_arginfo.h" role="src" />
    <file name="php_memprof.h" role="src" />
    <file name="util.c" role="src" />
    <file name="util.h" role="src" />


### PR DESCRIPTION
Here is an implementation of generated arginfo from stub.php

Notice: *arginfo.h  are auto-generated when stud.php is altered, but only if using PHP 8+

* For PHP 8,  this also introduces type hinting (for return type in this ext)
* For PHP 7, legacy file is used, so reflection is unchanged.


I have no real idea of what can be done for alias
