### PR TITLE
Append filename to OOM message when dump_on_limit is triggered, and handle dump failures

### DIFF
--- a/tests/autodump-failure.phpt
+++ b/tests/autodump-failure.phpt
@@ -1,0 +1,33 @@
+--TEST--
+autodump
+--ENV--
+MEMPROF_PROFILE=dump_on_limit
+--FILE--
+<?php
+
+var_dump(memprof_enabled_flags());
+
+$buf = str_repeat("a", 5<<20);
+
+ini_set("memprof.output_dir", "/does-not-exist");
+ini_set("memory_limit", 15<<20);
+
+function f() {
+    $a = [];
+    for (;;) {
+        $a[] = str_repeat("a", 1<<20);
+    }
+}
+
+f();
+--EXPECTF--
+array(3) {
+  ["enabled"]=>
+  bool(true)
+  ["native"]=>
+  bool(false)
+  ["dump_on_limit"]=>
+  bool(true)
+}
+
+Fatal error: Allowed memory size of 15728640 bytes exhausted%S (tried to allocate %d bytes) (memprof failed dumping to %smemprof.callgrind%s, please check file permissions or disk capacity) in %s on line%a

--- a/tests/autodump.phpt
+++ b/tests/autodump.phpt
@@ -40,7 +40,7 @@ array(3) {
   bool(true)
 }
 
-Fatal error: Allowed memory size of 15728640 bytes exhausted%S (tried to allocate %d bytes) in %s on line%a
+Fatal error: Allowed memory size of 15728640 bytes exhausted%S (tried to allocate %d bytes) (memprof dumped to %smemprof.callgrind%s) in %s on line%a
 array(3) {
   [0]=>
   string(1) "."

--- a/tests/dump-failure.phpt
+++ b/tests/dump-failure.phpt
@@ -1,0 +1,37 @@
+--TEST--
+memprof_dump_ failure
+--ENV--
+MEMPROF_PROFILE=1
+--FILE--
+<?php
+
+require __DIR__ . '/common.php';
+
+ini_set("error_reporting", 0);
+
+$a = eat();
+$b = Eater::eat();
+
+$fd = fopen(__FILE__, "r");
+
+try {
+    memprof_dump_array();
+} catch (\Exception $e) {
+    echo "Exception: ", $e->getMessage(), "\n";
+}
+
+try {
+    memprof_dump_callgrind($fd);
+} catch (\Exception $e) {
+    echo "Exception: ", $e->getMessage(), "\n";
+}
+
+try {
+    memprof_dump_pprof($fd);
+} catch (\Exception $e) {
+    echo "Exception: ", $e->getMessage(), "\n";
+}
+
+--EXPECTF--
+Exception: memprof_dump_callgrind(): dump failed, please check file permissions or disk capacity
+Exception: memprof_dump_pprof(): dump failed, please check file permissions or disk capacity

--- a/tests/dump-pprof.phpt
+++ b/tests/dump-pprof.phpt
@@ -1,0 +1,27 @@
+--TEST--
+memprof_dump_pprof()
+--ENV--
+MEMPROF_PROFILE=1
+--FILE--
+<?php
+
+require __DIR__ . '/common.php';
+
+$a = eat();
+$b = Eater::eat();
+
+memprof_dump_pprof(STDOUT);
+
+--EXPECTF--
+--- symbol
+binary=todo.php
+0x0000000000000008 root
+0x0000000000000010 require %sdump-pprof.php
+0x0000000000000018 require %scommon.php
+0x0000000000000020 eat
+0x0000000000000028 str_repeat
+0x0000000000000030 Eater::eat
+0x0000000000000038 memprof_dump_pprof
+---
+--- profile
+%s

--- a/util.c
+++ b/util.c
@@ -15,24 +15,27 @@
 #include "php.h"
 #include <stdarg.h>
 
-void stream_printf(php_stream * stream, const char * format, ...)
+zend_bool stream_printf(php_stream * stream, const char * format, ...)
 {
 	char * buf;
 	va_list ap;
 	int len;
+	zend_bool result;
 
 	va_start(ap, format);
 	len = vspprintf(&buf, 0, format, ap);
 	va_end(ap);
 
-	php_stream_write(stream, buf, len);
+	result = php_stream_write(stream, buf, len) == len;
 
 	efree(buf);
+
+	return result;
 }
 
-void stream_write_word(php_stream * stream, zend_uintptr_t word)
+zend_bool stream_write_word(php_stream * stream, zend_uintptr_t word)
 {
-	php_stream_write(stream, (char*) &word, sizeof(word));
+	return php_stream_write(stream, (char*) &word, sizeof(word)) == sizeof(word);
 }
 
 size_t get_function_name(zend_execute_data * execute_data, char * buf, size_t buf_size)

--- a/util.h
+++ b/util.h
@@ -12,8 +12,8 @@
   +----------------------------------------------------------------------+
 */
 
-void stream_printf(php_stream * stream, const char * format, ...);
-void stream_write_word(php_stream * stream, zend_uintptr_t word);
+zend_bool stream_printf(php_stream * stream, const char * format, ...);
+zend_bool stream_write_word(php_stream * stream, zend_uintptr_t word);
 
 size_t get_function_name(zend_execute_data * execute_data, char * buf, size_t buf_size);
 


### PR DESCRIPTION
Memprof dumps the active profile when in dump_on_limit mode and the memory_limit is reached.

Here we expose the name of the dump file in the OOM message:

    Allowed memory size of 15728640 bytes exhausted (tried to allocate %d bytes) (memprof dumped to ...)

In case the dump failed, we expose this fact as well:

    Allowed memory size of 15728640 bytes exhausted (tried to allocate %d bytes) (memprof failed dumping to ..., please check file permissions or disk capacity)