### PR TITLE
Handle xdebug conflict on dump_on_limit feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
             - name: 'Build PHP'
               run: './ext/.github/workflows/test/build-php.sh'
 
+            - name: 'Install xdebug'
+              run: './ext/.github/workflows/test/build-xdebug.sh'
+
             - name: 'Build extension'
               run: './ext/.github/workflows/test/build-extension.sh'
 

--- a/.github/workflows/test/build-xdebug.sh
+++ b/.github/workflows/test/build-xdebug.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+export PATH="$HOME/php/bin:$PATH"
+hash -r
+
+git clone --depth 1 --branch "3.1.2" "https://github.com/xdebug/xdebug.git"
+
+cd xdebug
+
+phpize
+./configure
+make
+sudo make install

--- a/.github/workflows/test/tests.sh
+++ b/.github/workflows/test/tests.sh
@@ -13,5 +13,9 @@ if [ "$MEMORY_CHECK" = "1" ]; then
       checkmem=-m
 fi
 
+# Hack to ensure that run-tests.php attempts to load xdebug as a zend_extension
+# This hack is necessary with PHP < 8.1
+sed -i "s/if (\$req_ext == 'opcache') {/if (\$req_ext == 'opcache' || \$req_ext == 'xdebug') {/" run-tests.php || true
+
 PHP=$(which php)
 REPORT_EXIT_STATUS=1 TEST_PHP_EXECUTABLE="$PHP" "$PHP" run-tests.php -q $checkmem --show-diff $showmem

--- a/tests/autodump-xdebug.phpt
+++ b/tests/autodump-xdebug.phpt
@@ -1,0 +1,65 @@
+--TEST--
+autodump vs xdebug
+--EXTENSIONS--
+xdebug
+--INI--
+xdebug.mode=develop
+--ENV--
+MEMPROF_PROFILE=dump_on_limit
+--FILE--
+<?php
+
+$dir = sys_get_temp_dir() . '/' . microtime(true);
+var_dump($dir);
+var_dump(mkdir($dir));
+var_dump(memprof_enabled_flags());
+
+$buf = str_repeat("a", 5<<20);
+
+register_shutdown_function(function () use (&$buf, $dir) {
+    $buf = "";
+    var_dump(scandir($dir));
+});
+
+ini_set("memprof.output_dir", $dir);
+ini_set("memory_limit", 15<<20);
+
+function f() {
+    $a = [];
+    for (;;) {
+        $a[] = str_repeat("a", 1<<20);
+    }
+}
+
+f();
+--EXPECTF--
+%sautodump-xdebug.php:%d:
+string(%d) "/%s"
+%sautodump-xdebug.php:%d:
+bool(true)
+%sautodump-xdebug.php:%d:
+array(3) {
+  'enabled' =>
+  bool(true)
+  'native' =>
+  bool(false)
+  'dump_on_limit' =>
+  bool(true)
+}
+
+Fatal error: Allowed memory size of 15728640 bytes exhausted%S (tried to allocate %d bytes) (memprof dumped to %smemprof.callgrind%s) in %s on line%a
+
+Call Stack:
+    %s
+    %s
+    %s
+
+%sautodump-xdebug.php:%d:
+array(3) {
+  [0] =>
+  string(1) "."
+  [1] =>
+  string(2) ".."
+  [2] =>
+  string(%d) "memprof.callgrind.%s"
+}


### PR DESCRIPTION
xdebug overrides `zend_error_cb` after memprof, which removes our ability to see OOMs.

Here we try to override zend_error_cb as late as possible, so that xdebug doesn't conflicts anymore.