### PR TITLE
Use filename for script and binary instead of `/todo.php`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.*
+
+!.gitignore
+
 *.dep
 *.la
 *.lo

--- a/memprof.c
+++ b/memprof.c
@@ -1415,7 +1415,7 @@ static zend_bool dump_frame_callgrind(php_stream * stream, frame * f, char * fna
 	}
 
 	if (
-		!stream_printf(stream, "fl=/todo.php\n") ||
+		!stream_printf(stream, "fl=%s\n", stream->orig_path) ||
 		!stream_printf(stream, "fn=%s\n", fname)
 	) {
 		return 0;
@@ -1447,7 +1447,7 @@ static zend_bool dump_frame_callgrind(php_stream * stream, frame * f, char * fna
 		frame_inclusive_cost(next, &call_size, &call_count);
 
 		if (
-			!stream_printf(stream, "cfl=/todo.php\n")						||
+			!stream_printf(stream, "cfl=%s\n", stream->orig_path)			||
 			!stream_printf(stream, "cfn=%s\n", ZSTR_VAL(str_key))			||
 			!stream_printf(stream, "calls=%zu 1\n", next->calls)			||
 			!stream_printf(stream, "1 %zu %zu\n", call_size, call_count)
@@ -1573,7 +1573,7 @@ static zend_bool dump_frames_pprof_symbols(php_stream * stream, HashTable * symb
 static zend_bool dump_pprof_symbols_section(php_stream * stream, HashTable * symbols) {
 	return (
 		stream_printf(stream, "--- symbol\n")					&&
-		stream_printf(stream, "binary=todo.php\n")				&&
+		stream_printf(stream, "binary=%s\n", stream->orig_path)	&&
 
 		dump_frames_pprof_symbols(stream, symbols, &root_frame)	&&
 

--- a/tests/003.phpt
+++ b/tests/003.phpt
@@ -19,14 +19,14 @@ cmd: unknown
 positions: line
 events: MemorySize BlocksCount
 
-fl=/todo.php
+fl=php://stdout
 fn=Eater::eat
 1 8388640 1
 
-fl=/todo.php
+fl=php://stdout
 fn=root
 1 3145760 1
-cfl=/todo.php
+cfl=php://stdout
 cfn=Eater::eat
 calls=1 1
 1 8388640 1

--- a/tests/dump-pprof.phpt
+++ b/tests/dump-pprof.phpt
@@ -14,7 +14,7 @@ memprof_dump_pprof(STDOUT);
 
 --EXPECTF--
 --- symbol
-binary=todo.php
+binary=php://stdout
 0x0000000000000008 root
 0x0000000000000010 require %sdump-pprof.php
 0x0000000000000018 require %scommon.php


### PR DESCRIPTION
Resolves #58 

This is incomplete, the tests pass but it requires verification with actual usage.