### PR TITLE
Allow output_format to be defined from ini setting

### DIFF
--- a/memprof.c
+++ b/memprof.c
@@ -851,6 +851,7 @@ static char * generate_filename(const char * format) {
 static void memprof_zend_error_cb_dump(MEMPROF_ZEND_ERROR_CB_ARGS)
 {
 	char * filename = NULL;
+	const char * output_format = MEMPROF_G(output_dir);
 	php_stream * stream;
 	zend_bool error = 0;
 #if PHP_VERSION_ID < 80000
@@ -865,7 +866,7 @@ static void memprof_zend_error_cb_dump(MEMPROF_ZEND_ERROR_CB_ARGS)
 	zend_mm_set_heap(zheap);
 
 	WITHOUT_MALLOC_TRACKING {
-		if (MEMPROF_G(output_format) == FORMAT_CALLGRIND) {
+		if (strcmp(output_format, "callgrind") != 0) {
 			filename = generate_filename("callgrind");
 			stream = php_stream_open_wrapper_ex(filename, "w", 0, NULL, NULL);
 			if (stream != NULL) {
@@ -874,7 +875,7 @@ static void memprof_zend_error_cb_dump(MEMPROF_ZEND_ERROR_CB_ARGS)
 			} else {
 				error = 1;
 			}
-		} else if (MEMPROF_G(output_format) == FORMAT_PPROF) {
+		} else if (strcmp(output_format, "pprof") != 0) {
 			filename = generate_filename("pprof");
 			stream = php_stream_open_wrapper_ex(filename, "w", 0, NULL, NULL);
 			if (stream != NULL) {
@@ -883,6 +884,9 @@ static void memprof_zend_error_cb_dump(MEMPROF_ZEND_ERROR_CB_ARGS)
 			} else {
 				error = 1;
 			}
+		} else {
+			new_message = strpprintf(0, "%s (memprof failed dumping with format %s, please check the output format)", message_chr, output_format);
+			error = 1;
 		}
 
 		if (filename != NULL) {
@@ -1193,6 +1197,7 @@ ZEND_GET_MODULE(memprof)
  */
 PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("memprof.output_dir", MEMPROF_TEMP_DIR, PHP_INI_ALL, OnUpdateStringUnempty, output_dir, zend_memprof_globals, memprof_globals)
+	STD_PHP_INI_ENTRY("memprof.output_format", "callgrind", PHP_INI_ALL, OnUpdateStringUnempty, output_format, zend_memprof_globals, memprof_globals)
 PHP_INI_END()
 /* }}} */
 
@@ -1305,7 +1310,7 @@ PHP_MINFO_FUNCTION(memprof)
 PHP_GINIT_FUNCTION(memprof)
 {
 	memprof_globals->output_dir = NULL;
-	memprof_globals->output_format = FORMAT_CALLGRIND;
+	memprof_globals->output_format = "callgrind";
 }
 /* }}} */
 

--- a/package.xml
+++ b/package.xml
@@ -55,6 +55,8 @@
      <file name="007.phpt" role="test" />
      <file name="autodump-disabled.phpt" role="test" />
      <file name="autodump-failure.phpt" role="test" />
+     <file name="autodump-format-failure.phpt" role="test" />
+     <file name="autodump-pprof.phpt" role="test" />
      <file name="autodump.phpt" role="test" />
      <file name="autodump-xdebug.phpt" role="test" />
      <file name="common.php" role="test" />

--- a/php_memprof.h
+++ b/php_memprof.h
@@ -37,11 +37,6 @@ extern zend_module_entry memprof_module_entry;
 #   define PHP_FE_END { NULL, NULL, NULL, 0, 0 }
 #endif
 
-typedef enum {
-	FORMAT_CALLGRIND = 0,
-	FORMAT_PPROF = 1,
-} memprof_output_format;
-
 typedef struct _memprof_profile_flags {
 	zend_bool enabled;
 	zend_bool native;
@@ -50,7 +45,7 @@ typedef struct _memprof_profile_flags {
 
 ZEND_BEGIN_MODULE_GLOBALS(memprof)
 	const char * output_dir;
-	memprof_output_format output_format;
+	const char * output_format;
 	memprof_profile_flags profile_flags;
 ZEND_END_MODULE_GLOBALS(memprof)
 

--- a/php_memprof.h
+++ b/php_memprof.h
@@ -37,6 +37,11 @@ extern zend_module_entry memprof_module_entry;
 #   define PHP_FE_END { NULL, NULL, NULL, 0, 0 }
 #endif
 
+typedef enum {
+	FORMAT_CALLGRIND = 0,
+	FORMAT_PPROF = 1,
+} memprof_output_format;
+
 typedef struct _memprof_profile_flags {
 	zend_bool enabled;
 	zend_bool native;
@@ -45,11 +50,14 @@ typedef struct _memprof_profile_flags {
 
 ZEND_BEGIN_MODULE_GLOBALS(memprof)
 	const char * output_dir;
-	const char * output_format;
+	memprof_output_format output_format;
 	memprof_profile_flags profile_flags;
 ZEND_END_MODULE_GLOBALS(memprof)
 
 #define MEMPROF_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(memprof, v)
+
+#define MEMPROF_OUTPUT_FORMAT_CALLGRIND "callgrind"
+#define MEMPROF_OUTPUT_FORMAT_PPROF "pprof"
 
 PHP_MINIT_FUNCTION(memprof);
 PHP_MSHUTDOWN_FUNCTION(memprof);

--- a/tests/autodump-format-failure.phpt
+++ b/tests/autodump-format-failure.phpt
@@ -1,0 +1,50 @@
+--TEST--
+autodump
+--ENV--
+MEMPROF_PROFILE=dump_on_limit
+--FILE--
+<?php
+
+$dir = sys_get_temp_dir() . '/' . microtime(true);
+var_dump($dir);
+var_dump(mkdir($dir));
+var_dump(memprof_enabled_flags());
+
+$buf = str_repeat("a", 5<<20);
+
+register_shutdown_function(function () use (&$buf, $dir) {
+    $buf = "";
+    var_dump(scandir($dir));
+});
+
+ini_set("memprof.output_dir", $dir);
+ini_set("memprof.output_format", "nope");
+ini_set("memory_limit", 15<<20);
+
+function f() {
+    $a = [];
+    for (;;) {
+        $a[] = str_repeat("a", 1<<20);
+    }
+}
+
+f();
+--EXPECTF--
+string(%d) "/%s"
+bool(true)
+array(3) {
+  ["enabled"]=>
+  bool(true)
+  ["native"]=>
+  bool(false)
+  ["dump_on_limit"]=>
+  bool(true)
+}
+
+Fatal error: Invalid memprof.output_format setting. Should be "callgrind" or "pprof" in %s on line %a
+array(2) {
+  [0]=>
+  string(1) "."
+  [1]=>
+  string(2) ".."
+}

--- a/tests/autodump-pprof.phpt
+++ b/tests/autodump-pprof.phpt
@@ -1,0 +1,52 @@
+--TEST--
+autodump
+--ENV--
+MEMPROF_PROFILE=dump_on_limit
+--FILE--
+<?php
+
+$dir = sys_get_temp_dir() . '/' . microtime(true);
+var_dump($dir);
+var_dump(mkdir($dir));
+var_dump(memprof_enabled_flags());
+
+$buf = str_repeat("a", 5<<20);
+
+register_shutdown_function(function () use (&$buf, $dir) {
+    $buf = "";
+    var_dump(scandir($dir));
+});
+
+ini_set("memprof.output_dir", $dir);
+ini_set("memprof.output_format", "pprof");
+ini_set("memory_limit", 15<<20);
+
+function f() {
+    $a = [];
+    for (;;) {
+        $a[] = str_repeat("a", 1<<20);
+    }
+}
+
+f();
+--EXPECTF--
+string(%d) "/%s"
+bool(true)
+array(3) {
+  ["enabled"]=>
+  bool(true)
+  ["native"]=>
+  bool(false)
+  ["dump_on_limit"]=>
+  bool(true)
+}
+
+Fatal error: Allowed memory size of 15728640 bytes exhausted%S (tried to allocate %d bytes) (memprof dumped to %smemprof.pprof%s) in %s on line%a
+array(3) {
+  [0]=>
+  string(1) "."
+  [1]=>
+  string(2) ".."
+  [2]=>
+  string(%d) "memprof.pprof.%s"
+}


### PR DESCRIPTION
Hi @arnaud-lb,

I have not written C since a long time, I expect my code to not be as clean as it should.

~~I have one concern, I think the `output_format` should be validated before calling `memprof_zend_error_cb_dump`.~~

Looking forward your feedback :slightly_smiling_face: 