### PR TITLE
Add PHP 8.2 & 8.3 to Github Action matrix tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,11 @@ jobs:
           - php: '8.3.0'
             os: 'ubuntu-22.04'
             expect_native: 1
-            werror: 1
             xdebug: '3.3.0alpha3'
 
           - php: '8.2.0'
             os: 'ubuntu-22.04'
             expect_native: 1
-            werror: 1
             xdebug: '3.2.2'
 
           - php: '8.1.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,10 @@ jobs:
         include:
           - php: '8.3.0'
             os: 'ubuntu-22.04'
-            expect_native: 1
             xdebug: '3.3.0alpha3'
 
           - php: '8.2.0'
             os: 'ubuntu-22.04'
-            expect_native: 1
             xdebug: '3.2.2'
 
           - php: '8.1.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,18 @@ jobs:
     strategy:
       matrix:
         include:
+          - php: '8.3.0'
+            os: 'ubuntu-22.04'
+            expect_native: 1
+            werror: 1
+            xdebug: '3.3.0alpha3'
+
+          - php: '8.2.0'
+            os: 'ubuntu-22.04'
+            expect_native: 1
+            werror: 1
+            xdebug: '3.2.2'
+
           - php: '8.1.0'
             os: 'ubuntu-20.04'
             expect_native: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,12 @@ jobs:
         include:
           - php: '8.3.0'
             os: 'ubuntu-22.04'
+            werror: 1
             xdebug: '3.3.0alpha3'
 
           - php: '8.2.0'
             os: 'ubuntu-22.04'
+            werror: 1
             xdebug: '3.2.2'
 
           - php: '8.1.0'

--- a/memprof.c
+++ b/memprof.c
@@ -123,8 +123,6 @@
 
 #else /* HAVE_MALLOC_HOOKS */
 
-#	warning No support for malloc hooks, this build will not track persistent allocations
-
 #	define MALLOC_HOOK_CHECK_NOT_OWN()
 #	define MALLOC_HOOK_IS_SET() (__malloc_hook == malloc_hook)
 #	define MALLOC_HOOK_RESTORE_OLD()


### PR DESCRIPTION
This PR add PHP 8.2 & PHP 8.3 to Github Action matrix tests with Ubuntu 22.04 LTS.

Therefore `werror` must be disabled as well as `expect_native` because Ubuntu 22.04 uses glibc 2.34 where malloc hooks functions have been removed.

glibc NEWS file:
>* The deprecated functions malloc_get_state and malloc_set_state have been
  moved from the core C library into libc_malloc_debug.so.  Legacy applications
  that still use these functions will now need to preload libc_malloc_debug.so
  in their environment using the LD_PRELOAD environment variable.
>* The deprecated memory allocation hooks __malloc_hook, __realloc_hook,
  __memalign_hook and __free_hook are now removed from the API.  Compatibility
  symbols are present to support legacy programs but new applications can no
  longer link to these symbols.  These hooks no longer have any effect on glibc
  functionality.  The malloc debugging DSO libc_malloc_debug.so currently
  supports hooks and can be preloaded to get this functionality back for older
  programs.  However this is a transitional measure and may be removed in a
  future release of the GNU C Library.  Users may port away from these hooks by
  writing and preloading their own malloc interposition library.