### PR TITLE
Version-agnostic PECL installation on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Make sure to install [dependencies](#dependencies), and then:
     pecl install memprof
 
 On MacOS:
-    JUDY_DIR="/opt/homebrew/Cellar/judy/1.0.5" pecl install memprof
+    JUDY_DIR=$(brew --prefix traildb/judy/judy) pecl install memprof
 
 > **Note** If libjudy is installed in a non-standard path (not /usr or /usr/local), please use the manual installation method bellow.
 


### PR DESCRIPTION
Use Homebrew's symlink pointing to installed Judy version.